### PR TITLE
Add README for Flask web client

### DIFF
--- a/flask_frontend/README.md
+++ b/flask_frontend/README.md
@@ -1,0 +1,58 @@
+# WhisperLive Flask Frontend
+
+This directory contains a simple Flask application that can connect to a running WhisperLive server over HTTPS and stream microphone audio for real time transcription.
+
+## Prerequisites
+
+- Python 3.8 or later
+- Install server dependencies using `requirements/server.txt`
+- Install client dependencies using `requirements/client.txt`
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements/server.txt
+pip install -r requirements/client.txt
+pip install flask
+```
+
+## Running the Server
+
+1. In the repository root, start the transcription server:
+
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper
+```
+
+The server will listen on port `9090` for WebSocket connections.
+
+## Running the Flask Client
+
+1. Change to the `flask_frontend` directory:
+
+```bash
+cd flask_frontend
+```
+
+2. Start the Flask application (it uses an ad-hoc certificate for HTTPS):
+
+```bash
+python3 app.py
+```
+
+3. Open your browser and navigate to `https://localhost:5000`. Accept the browser security warning for the self-signed certificate.
+
+4. Click **Start** to stream microphone audio. The transcription will appear in the browser. Use **Download Transcript** to save the text as a `.txt` file.
+
+## Configuration
+
+The client assumes the server is running on `localhost:9090`. To change the server address, set the environment variables `WHISPER_SERVER_HOST` and `WHISPER_SERVER_PORT` before launching the Flask app:
+
+```bash
+export WHISPER_SERVER_HOST=your.server.address
+export WHISPER_SERVER_PORT=9090
+python3 app.py
+```
+
+The application requires HTTPS access to use the microphone; the built-in ad-hoc certificate is suitable for local development. For production usage, configure Flask with a valid certificate.
+

--- a/flask_frontend/app.py
+++ b/flask_frontend/app.py
@@ -1,0 +1,15 @@
+from flask import Flask, render_template
+import os
+
+app = Flask(__name__)
+
+SERVER_HOST = os.environ.get("WHISPER_SERVER_HOST", "localhost")
+SERVER_PORT = os.environ.get("WHISPER_SERVER_PORT", "9090")
+
+@app.route('/')
+def index():
+    return render_template('index.html', server_host=SERVER_HOST, server_port=SERVER_PORT)
+
+if __name__ == '__main__':
+    # Use adhoc certificate to allow https without extra setup
+    app.run(host='0.0.0.0', port=5000, ssl_context='adhoc')

--- a/flask_frontend/static/script.js
+++ b/flask_frontend/static/script.js
@@ -1,0 +1,110 @@
+let ws;
+let mediaRecorder;
+let audioContext;
+let processor;
+let audioStream;
+let transcript = [];
+let uid;
+
+const startBtn = document.getElementById('startBtn');
+const stopBtn = document.getElementById('stopBtn');
+const downloadBtn = document.getElementById('downloadBtn');
+const transcriptDiv = document.getElementById('transcript');
+
+function uuidv4() {
+    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    );
+}
+
+function resampleTo16k(buffer, sampleRate) {
+    const targetLength = Math.round(buffer.length * (16000 / sampleRate));
+    const resampled = new Float32Array(targetLength);
+    const step = (buffer.length - 1) / (targetLength - 1);
+    resampled[0] = buffer[0];
+    resampled[targetLength - 1] = buffer[buffer.length - 1];
+    for (let i = 1; i < targetLength - 1; i++) {
+        const idx = i * step;
+        const left = Math.floor(idx);
+        const right = Math.ceil(idx);
+        const frac = idx - left;
+        resampled[i] = buffer[left] + (buffer[right] - buffer[left]) * frac;
+    }
+    return resampled;
+}
+
+function initWebSocket() {
+    uid = uuidv4();
+    ws = new WebSocket(`wss://${SERVER_HOST}:${SERVER_PORT}/`);
+    ws.onopen = () => {
+        ws.send(JSON.stringify({
+            uid: uid,
+            language: 'en',
+            task: 'transcribe',
+            model: 'small',
+            use_vad: true
+        }));
+    };
+    ws.onmessage = event => {
+        const data = JSON.parse(event.data);
+        if (data.uid !== uid) return;
+        if (data.segments) {
+            data.segments.forEach(seg => {
+                if (seg.text && (!transcript.length || transcript[transcript.length-1] !== seg.text)) {
+                    transcript.push(seg.text);
+                    transcriptDiv.textContent = transcript.join(' ');
+                }
+            });
+        }
+    };
+}
+
+function startRecording() {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+        audioStream = stream;
+        audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        const source = audioContext.createMediaStreamSource(stream);
+        processor = audioContext.createScriptProcessor(4096, 1, 1);
+        processor.onaudioprocess = e => {
+            const inputData = e.inputBuffer.getChannelData(0);
+            const data16k = resampleTo16k(inputData, audioContext.sampleRate);
+            if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(data16k);
+            }
+        };
+        source.connect(processor);
+        processor.connect(audioContext.destination);
+        initWebSocket();
+        startBtn.disabled = true;
+        stopBtn.disabled = false;
+    }).catch(err => {
+        alert('Microphone access denied: ' + err);
+    });
+}
+
+function stopRecording() {
+    if (processor) processor.disconnect();
+    if (audioStream) audioStream.getTracks().forEach(t => t.stop());
+    if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send('END_OF_AUDIO');
+        ws.close();
+    }
+    stopBtn.disabled = true;
+    startBtn.disabled = false;
+    downloadBtn.disabled = false;
+}
+
+function downloadTranscript() {
+    const blob = new Blob([transcript.join(' ')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'transcript.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+startBtn.addEventListener('click', startRecording);
+stopBtn.addEventListener('click', stopRecording);
+downloadBtn.addEventListener('click', downloadTranscript);
+

--- a/flask_frontend/templates/index.html
+++ b/flask_frontend/templates/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>WhisperLive Web Client</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #transcript { white-space: pre-line; border: 1px solid #ccc; padding: 10px; height: 200px; overflow-y: auto; }
+        button { margin-right: 10px; }
+    </style>
+</head>
+<body>
+    <h1>WhisperLive Web Client</h1>
+    <button id="startBtn">Start</button>
+    <button id="stopBtn" disabled>Stop</button>
+    <button id="downloadBtn" disabled>Download Transcript</button>
+    <div id="transcript"></div>
+
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <script>
+        const SERVER_HOST = "{{ server_host }}";
+        const SERVER_PORT = "{{ server_port }}";
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document Flask-based web client
- show how to run WhisperLive server and client together

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for scipy and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686275a27c90832baaf0368452b5048e